### PR TITLE
Rocksdb support from old multiplier

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,7 @@ find_llvm(llvm)
 find_package(Clang CONFIG REQUIRED)
 find_package(gRPC CONFIG REQUIRED)
 find_package(Flatbuffers CONFIG REQUIRED)
+find_package(RocksDB CONFIG REQUIRED)
 
 find_package(DrLojekyll CONFIG REQUIRED)
 find_package(pasta CONFIG REQUIRED)

--- a/bin/Import/Importer.cpp
+++ b/bin/Import/Importer.cpp
@@ -305,7 +305,7 @@ bool Importer::ImportBlightCompileCommand(llvm::json::Object &o) {
   command.working_dir = cwd->str();
   command.compiler_hash = hash->str();
   command.env = std::move(envp);
-  if (lang->equals_lower("c++") || lang->equals_lower("cxx")) {
+  if (lang->equals_insensitive("c++") || lang->equals_insensitive("cxx")) {
     command.lang = pasta::TargetLanguage::kCXX;
   }
   return true;
@@ -328,9 +328,9 @@ bool Importer::ImportCMakeCompileCommand(llvm::json::Object &o) {
     command.working_dir = cwd->str();
 
     // Guess at the language.
-    if (args->contains_lower("++") || args->contains_lower(".cc") ||
-        args->contains_lower(".cxx") || args->contains_lower(".cpp") ||
-        args->contains_lower(".hxx") || args->contains_lower(".hpp")) {
+    if (args->contains_insensitive("++") || args->contains_insensitive(".cc") ||
+        args->contains_insensitive(".cxx") || args->contains_insensitive(".cpp") ||
+        args->contains_insensitive(".hxx") || args->contains_insensitive(".hpp")) {
       command.lang = pasta::TargetLanguage::kCXX;
     }
 

--- a/bin/Import/Parser.cpp
+++ b/bin/Import/Parser.cpp
@@ -97,7 +97,7 @@ bool Parser::ParseObject(llvm::object::ObjectFile *object) {
 
     // If we've found a section with embedded compile commands, then
     // try to parse them and import them.
-    if (name.contains_lower("trailofbits_cc")) {
+    if (name.contains_insensitive("trailofbits_cc")) {
 
       LOG(INFO)
           << "Found compile commands section in " << file_name;
@@ -151,7 +151,7 @@ bool Parser::ParseModule(const llvm::Module &module) {
     }
 
     auto section_name = var.getSection();
-    if (section_name.contains_lower("trailofbits_cc")) {
+    if (section_name.contains_insensitive("trailofbits_cc")) {
       LOG(INFO)
           << "Found compile command variable '" << var.getName()
           << "' in bitcode module " << module.getName();

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -106,6 +106,7 @@ add_library("tool"
     "Token.h"
     "TokenTree.cpp"
     "Tool.cpp"
+    "KeyValueStore.cpp"
 )
 
 
@@ -118,6 +119,7 @@ target_link_libraries("tool"
     
   PUBLIC
     DrLojekyll::Runtime
+    RocksDB::rocksdb
     "util")
 
 set_target_properties("tool"

--- a/lib/Datalog/GenerateTokens.cpp
+++ b/lib/Datalog/GenerateTokens.cpp
@@ -8,6 +8,7 @@
 
 #include <cstring>
 #include <fstream>
+#include <vector>
 
 int main(int argc, char *argv[]) {
   auto num_tokens = static_cast<unsigned>(clang::tok::TokenKind::NUM_TOKENS);

--- a/lib/KeyValueStore.cpp
+++ b/lib/KeyValueStore.cpp
@@ -1,0 +1,480 @@
+/*
+ * Copyright (c) 2019 Trail of Bits, Inc.
+ */
+
+#include "KeyValueStore.h"
+
+#include <glog/logging.h>
+
+#include <mutex>
+#include <sstream>
+#include <thread>
+
+// So that rocksdb::Slice has std::string_view conversion functions.
+#ifndef __cpp_lib_string_view
+# define __cpp_lib_string_view
+#endif
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wgnu-redeclared-enum"
+#include <rocksdb/cache.h>
+#include <rocksdb/db.h>
+#include <rocksdb/comparator.h>
+#include <rocksdb/convenience.h>
+#include <rocksdb/filter_policy.h>
+#include <rocksdb/merge_operator.h>
+#include <rocksdb/options.h>
+#include <rocksdb/slice_transform.h>
+#include <rocksdb/table.h>
+#pragma clang diagnostic pop
+
+
+namespace mx {
+
+// Implementation wrapper around RocksDB.
+class KeyValueStore::KeyValueEngine {
+ public:
+  ~KeyValueEngine(void);
+  explicit KeyValueEngine(std::filesystem::path kv_dir);
+
+  void Erase(const std::string &key);
+  void EraseMatchingPrefix(const std::string &key);
+
+  bool TryGet(const std::string &key, std::string *val);
+  void Set(const std::string &key, const std::string &val);
+  void MatchCommonPrefix(
+      const std::string &key_prefix,
+      std::function<bool(const std::string &, const std::string &)> cb);
+
+  void MatchRangesContainingKey(
+      const std::string &search_key_with_pfx,
+      std::function<bool(std::string_view low,
+                         std::string_view high,
+                         std::string_view key_suffix,
+                         std::string_view value)> cb);
+
+ private:
+  KeyValueEngine(void) = delete;
+
+  std::unique_ptr<rocksdb::DB> rocks_db;
+  rocksdb::ColumnFamilyHandle *cf_handle;
+};
+
+namespace {
+
+// Weak pointer to the global key-value storage engine shared by all instances.
+static std::weak_ptr<KeyValueStore::KeyValueEngine> gEngine;
+static std::mutex gEngineLock;
+
+enum : size_t {
+  kNumKeyShards = 1024UL
+};
+
+// When doing `GetOrSet` or `UpdateOrSet`,
+// we hash the key and grab a lock based on that hash.
+static std::mutex gKeyShards[kNumKeyShards];
+
+// NOTE(pag): Make sure all key prefixes are length exactly 4, as we used a
+//            fixed prefix extractor for the column family.
+static const char *IDToKeyPrefix(KeyValueStore::KeyValueStoreID id) {
+  switch (id) {
+    case KeyValueStore::kPathInfoFileStatus:
+      return "pis:";
+    case KeyValueStore::kPathInfoFileList:
+      return "pil:";
+    case KeyValueStore::kSourceConcatPathToOffset:
+      return "p2o:";
+    case KeyValueStore::kSourceConcatHashToOffset:
+      return "h2o:";
+    case KeyValueStore::kFileOffsetToTokenListId:
+      return "f2i:";
+    case KeyValueStore::kTopLevelDeclKeyToOffset:
+      return "t2o:";
+    case KeyValueStore::kTranslationUnits:
+      return "tus:";
+    case KeyValueStore::kEntities:
+      return "ent:";
+  }
+}
+
+// Gets or creates a new key-value storage engine.
+static std::shared_ptr<KeyValueStore::KeyValueEngine>
+GetEngine(KeyValueStore::KeyValueStoreID id, std::filesystem::path path) {
+  std::lock_guard<std::mutex> locker(gEngineLock);
+  auto ret = gEngine.lock();
+  if (ret) {
+    return ret;
+  }
+
+  auto kv_dir = path / "kv";
+  if (std::filesystem::is_directory(kv_dir)) {
+    std::error_code ec;
+    if (std::filesystem::create_directory(kv_dir, ec)) {
+      LOG(ERROR)
+          << "Unable to create directory '" << kv_dir.string()
+          << "' for key-value storage: " << ec.message();
+    }
+  }
+
+  ret = std::make_shared<KeyValueStore::KeyValueEngine>(kv_dir);
+  gEngine = ret;
+  return ret;
+}
+
+}  // namespace
+
+KeyValueStore::KeyValueEngine::~KeyValueEngine(void) {
+  LOG(INFO)
+      << "Shutting down key-value engine";
+
+  auto status = rocks_db->FlushWAL(true  /* sync */);
+  LOG_IF(ERROR, !status.ok() && !status.IsNotSupported())
+      << "Error flushing write-ahead log: " << status.ToString();
+
+  rocksdb::FlushOptions options;
+  options.wait = true;
+  status = rocks_db->Flush(options, cf_handle);
+  LOG_IF(ERROR, !status.ok())
+      << "Error flushing key/value store: " << status.ToString();
+
+  LOG(INFO)
+      << "Canceling background RocksDB work";
+  rocksdb::CancelAllBackgroundWork(rocks_db.get(), true  /* wait */);
+
+//  status = rocks_db->Close();
+//  LOG_IF(ERROR, !status.ok())
+//      << "Error closing key/value store: " << status.ToString();
+
+  // NOTE(pag): Intentional memory leak here.
+  (void) rocks_db.release();
+}
+
+KeyValueStore::KeyValueEngine::KeyValueEngine(std::filesystem::path kv_dir)
+    : cf_handle(nullptr) {
+
+  rocksdb::DBOptions options;
+  options.create_if_missing = true;
+  options.create_missing_column_families = true;
+  options.IncreaseParallelism(std::thread::hardware_concurrency());
+
+  std::vector<rocksdb::ColumnFamilyDescriptor> cf_descs;
+  rocksdb::ColumnFamilyOptions cf_options;
+  cf_options.compression = rocksdb::kZlibCompression;
+  cf_options.bottommost_compression = rocksdb::kZlibCompression;
+//  cf_options.compression_opts = rocksdb::CompressionOptions(
+//      15  /* MAX_WBITS */,
+//      9  /* Z_BEST_COMPRESSION */,
+//      0 /* Z_DEFAULT_STRATEGY */,
+//      0, 0, true);
+//  cf_options.bottommost_compression_opts = cf_options.compression_opts;
+  cf_options.prefix_extractor.reset(rocksdb::NewFixedPrefixTransform(4));
+  cf_descs.emplace_back(rocksdb::kDefaultColumnFamilyName, cf_options);
+
+  std::vector<rocksdb::ColumnFamilyHandle *> cf_handles;
+  rocksdb::DB *rocks_db_ptr = nullptr;
+  auto db_path = kv_dir.string();
+  auto status = rocksdb::DB::Open(options, db_path, cf_descs,
+                                  &cf_handles, &rocks_db_ptr);
+  CHECK(status.ok())
+      << "Unable to open RocksDB database at " << db_path << ": "
+      << status.ToString();
+
+  CHECK_EQ(cf_handles.size(), 1);
+
+  rocks_db.reset(rocks_db_ptr);
+  cf_handle = cf_handles[0];
+}
+
+void KeyValueStore::KeyValueEngine::Erase(const std::string &key_) {
+  rocksdb::Slice key(key_);
+  rocksdb::WriteOptions options;
+
+  const auto status = rocks_db->Delete(options, key);
+  CHECK(status.ok())
+      << "Unable to remove key '" << key_ << "' in key-value store: "
+      << status.ToString();
+}
+
+// NOTE(pag): `full_key_prefix_` includes `KeyValueStore::key_prefix`.
+void KeyValueStore::KeyValueEngine::EraseMatchingPrefix(
+    const std::string &full_key_prefix_) {
+  rocksdb::Slice full_key_prefix(full_key_prefix_);
+  rocksdb::ReadOptions read_options;
+  read_options.prefix_same_as_start = true;
+  rocksdb::WriteOptions write_options;
+  rocksdb::WriteBatch batch;
+
+  std::unique_ptr<rocksdb::Iterator> it(
+      rocks_db->NewIterator(read_options, cf_handle));
+
+  auto num_found = 0;
+  for (it->Seek(full_key_prefix); it->Valid(); it->Next()) {
+    auto key = it->key();
+    if (!key.starts_with(full_key_prefix)) {
+      break;
+    }
+    ++num_found;
+    batch.Delete(cf_handle, key);
+  }
+
+  it.reset();
+
+  if (!num_found) {
+    return;
+  }
+
+  const auto status = rocks_db->Write(write_options, &batch);
+  CHECK(status.ok())
+      << "Unable to remove all keys sharing prefix '" << full_key_prefix_
+      << "' in key-value store: " << status.ToString();
+}
+
+bool KeyValueStore::KeyValueEngine::TryGet(const std::string &key_,
+                                           std::string *val_) {
+  rocksdb::Slice key(key_);
+  rocksdb::ReadOptions options;
+  const auto status = rocks_db->Get(options, cf_handle, key, val_);
+  if (status.IsNotFound()) {
+    return false;
+  }
+
+  CHECK(status.ok())
+      << "Unable to value for key '" << key_ << "' in key-value store: "
+      << status.ToString();
+
+  return true;
+}
+
+void KeyValueStore::KeyValueEngine::Set(const std::string &key_,
+                                        const std::string &val_) {
+  const rocksdb::Slice key(key_);
+  const rocksdb::Slice val(val_);
+  const rocksdb::WriteOptions options;
+
+  const auto status = rocks_db->Put(options, cf_handle, key, val);
+  CHECK(status.ok())
+      << "Unable to map key '" << key_ << "' to value '" << val_
+      << "' in key-value store: " << status.ToString();
+}
+
+// Invoke a callback for each key/value pair, where all the keys share a
+// common prefix.
+void KeyValueStore::KeyValueEngine::MatchCommonPrefix(
+    const std::string &full_key_prefix_,
+    std::function<bool(const std::string &, const std::string &)> cb) {
+
+  rocksdb::ReadOptions options;
+  options.prefix_same_as_start = true;
+
+  const rocksdb::Slice full_key_prefix(full_key_prefix_);
+
+  std::unique_ptr<rocksdb::Iterator> it(
+      rocks_db->NewIterator(options, cf_handle));
+
+  for (it->Seek(full_key_prefix); it->Valid(); it->Next()) {
+    auto key = it->key();
+    if (!key.starts_with(full_key_prefix)) {
+      break;
+    }
+    key.remove_prefix(4);
+    if (!cb(key.ToString(), it->value().ToString())) {
+      break;
+    }
+  }
+}
+
+void KeyValueStore::KeyValueEngine::MatchRangesContainingKey(
+    const std::string &search_key_with_pfx,
+    std::function<bool(std::string_view low,
+                       std::string_view high,
+                       std::string_view key_suffix,
+                       std::string_view value)> cb) {
+
+  rocksdb::ReadOptions options;
+
+  std::unique_ptr<rocksdb::Iterator> it(
+      rocks_db->NewIterator(options, cf_handle));
+
+  std::string_view search_key = search_key_with_pfx;
+  search_key.remove_prefix(4);
+  auto search_key_length = search_key.length();
+
+  for (it->Seek(search_key_with_pfx); it->Valid(); it->Next()) {
+    auto key = it->key().ToStringView();
+    key.remove_prefix(4);
+
+    auto high = key.substr(0, search_key_length);
+    key.remove_prefix(search_key_length);
+    CHECK_EQ(key[0], ':');
+    key.remove_prefix(1);
+
+    auto low = key.substr(0, search_key_length);
+    key.remove_prefix(search_key_length);
+    CHECK_EQ(key[0], ':');
+    key.remove_prefix(1);
+
+    CHECK(low <= high);
+
+    if (!(low <= search_key && search_key <= high)) {
+      continue;
+    }
+
+    auto value = it->value().ToStringView();
+    if (!cb(low, high, key, value)) {
+      break;
+    }
+  }
+}
+
+KeyValueStore::~KeyValueStore(void) {}
+
+KeyValueStore::KeyValueStore(KeyValueStoreID id, std::filesystem::path path)
+    : engine(GetEngine(id, path)),
+      key_prefix(IDToKeyPrefix(id)) {}
+
+KeyValueStore::KeyValueStore(const KeyValueStore &that)
+    : engine(that.engine),
+      key_prefix(that.key_prefix) {}
+
+KeyValueStore::KeyValueStore(KeyValueStore &&that) noexcept
+    : engine(std::move(that.engine)),
+      key_prefix(std::move(that.key_prefix)) {}
+
+// Erase a key/value pair with the key `key`.
+void KeyValueStore::Erase(const std::string &key) {
+  std::stringstream ss;
+  ss << key_prefix << key;
+  engine->Erase(ss.str());
+}
+
+// Erase all key/value pair with whose key matches the prefix `key_prefix`.
+void KeyValueStore::EraseMatchingPrefix(const std::string &key_prefix_) {
+  std::stringstream ss;
+  ss << key_prefix << key_prefix_;
+  engine->EraseMatchingPrefix(ss.str());
+}
+
+// Try to get the value associated with `key` in the store. If the value
+// exists, then `val` is updated, and `true` is returned. Otherwise `false`
+// is returned.
+bool KeyValueStore::TryGetImpl(const std::string &key, std::string *val) {
+  std::stringstream ss;
+  ss << key_prefix << key;
+  return engine->TryGet(ss.str(), val);
+}
+
+// Set the value associated with `key` in the store to `val`.
+void KeyValueStore::SetImpl(const std::string &key, const std::string &val) {
+  std::stringstream ss;
+  ss << key_prefix << key;
+  engine->Set(ss.str(), val);
+}
+
+// Invoke a callback for each key/value pair.
+void KeyValueStore::MatchAll(
+    std::function<bool(const std::string &, const std::string &)> cb) {
+  engine->MatchCommonPrefix(key_prefix, cb);
+}
+
+// Invoke a callback for each key/value pair, where all the keys share a
+// common prefix.
+void KeyValueStore::MatchCommonPrefix(
+    const std::string &key_prefix_,
+    std::function<bool(const std::string &, const std::string &)> cb) {
+  std::stringstream ss;
+  ss << key_prefix << key_prefix_;
+  engine->MatchCommonPrefix(ss.str(), cb);
+}
+
+void KeyValueStore::MatchRangesContainingKey(
+    const std::string &search_key,
+    std::function<bool(std::string_view low,
+                       std::string_view high,
+                       std::string_view key_suffix,
+                       std::string_view value)> cb) {
+  std::stringstream ss;
+  ss << key_prefix << search_key;
+  engine->MatchRangesContainingKey(ss.str(), cb);
+}
+
+// Implements an atomic set if the value is missing. Returns `true` if the
+// value was missing.
+//
+// NOTE(pag): This is only atomic with respect to other `GetOrSet` calls.
+bool KeyValueStore::SetIfMissing(
+    const std::string &key, std::function<std::string(void)> get_val_for_set) {
+
+  std::stringstream ss;
+  ss << key_prefix << key;
+  const auto real_key = ss.str();
+
+  std::string ret;
+  if (engine->TryGet(real_key, &ret)) {
+    return false;
+  }
+
+  std::hash<std::string> hasher;
+  const auto hash_val = hasher(real_key);
+  std::lock_guard<std::mutex> locker(gKeyShards[hash_val % kNumKeyShards]);
+
+  if (engine->TryGet(real_key, &ret)) {
+    return false;
+  }
+
+  ret = get_val_for_set();
+  engine->Set(real_key, ret);
+  return true;
+}
+
+// Implements an atomic get or set.
+//
+// NOTE(pag): This is only atomic with respect to other `GetOrSet` calls.
+// NOTE(ppalka): And also with respect to `UpdateOrSet` calls.
+std::string KeyValueStore::GetOrSet(
+    const std::string &key, std::function<std::string(void)> get_val_for_set) {
+
+  std::stringstream ss;
+  ss << key_prefix << key;
+  const auto real_key = ss.str();
+
+  std::string ret;
+  if (engine->TryGet(real_key, &ret)) {
+    return ret;
+  }
+
+  std::hash<std::string> hasher;
+  const auto hash_val = hasher(real_key);
+  std::lock_guard<std::mutex> locker(gKeyShards[hash_val % kNumKeyShards]);
+
+  if (engine->TryGet(real_key, &ret)) {
+    return ret;
+  }
+
+  ret = get_val_for_set();
+  engine->Set(real_key, ret);
+
+  return ret;
+}
+
+std::string KeyValueStore::UpdateOrSet(
+    const std::string &key,
+    std::function<std::string(const std::string *)> update_val) {
+
+  std::stringstream ss;
+  ss << key_prefix << key;
+  const auto real_key = ss.str();
+
+  std::hash<std::string> hasher;
+  const auto hash_val = hasher(real_key);
+  std::lock_guard<std::mutex> locker(gKeyShards[hash_val % kNumKeyShards]);
+
+  std::string ret;
+  bool exists = engine->TryGet(real_key, &ret);
+
+  ret = update_val(exists ? &ret : nullptr);
+  engine->Set(real_key, ret);
+
+  return ret;
+}
+
+}  // namespace mu

--- a/lib/KeyValueStore.h
+++ b/lib/KeyValueStore.h
@@ -1,0 +1,221 @@
+/*
+ * Copyright (c) 2019 Trail of Bits, Inc.
+ */
+
+#pragma once
+
+#include <functional>
+#include <memory>
+#include <string>
+#include <sstream>
+#include <type_traits>
+
+#include <glog/logging.h>
+#include <google/protobuf/message.h>
+
+#include <pasta/Util/FileSystem.h>
+
+namespace mx {
+
+// Persistent key value storage for workspaces.
+class KeyValueStore {
+ public:
+  enum KeyValueStoreID {
+    kPathInfoFileStatus,
+    kPathInfoFileList,
+    kSourceConcatPathToOffset,
+    kSourceConcatHashToOffset,
+    kFileOffsetToTokenListId,
+    kTopLevelDeclKeyToOffset,
+    kTranslationUnits,
+    kEntities
+  };
+
+  ~KeyValueStore(void);
+
+  explicit KeyValueStore(KeyValueStoreID id_, std::filesystem::path path);
+  KeyValueStore(const KeyValueStore &that);
+  KeyValueStore(KeyValueStore &&that) noexcept;
+
+  // Erase a key/value pair with the key `key`.
+  void Erase(const std::string &key);
+
+  // Erase all key/value pair with whose key matches the prefix `key_prefix`.
+  void EraseMatchingPrefix(const std::string &key_prefix);
+
+  // Try to get the value associated with `key` in the store. If the value
+  // exists, then `val` is updated, and `true` is returned. Otherwise `false`
+  // is returned.
+  inline bool TryGet(const std::string &key, std::string *val) {
+    return TryGetImpl(key, val);
+  }
+
+  // Set the value associated with `key` in the store to `val`.
+  inline void Set(const std::string &key, const std::string &val) {
+    return SetImpl(key, val);
+  }
+
+  // Implements an atomic set if the value is missing. Returns `true` if the
+  // value was missing.
+  //
+  // NOTE(pag): This is only atomic with respect to other `GetOrSet` calls.
+  bool SetIfMissing(const std::string &key,
+                    std::function<std::string(void)> get_val_for_set);
+
+  // Implements an atomic get or set.
+  //
+  // NOTE(pag): This is only atomic with respect to other `GetOrSet` calls.
+  // NOTE(ppalka): And with respect to `UpdateOrSet` calls.
+  std::string GetOrSet(const std::string &key,
+                       std::function<std::string(void)> get_val_for_set);
+
+  template <typename T, typename C>
+  inline T GetOrSet(const std::string &key, C get_val_for_set) {
+    auto do_get_val_for_set = [this, &get_val_for_set] (void) -> std::string {
+      const T ret1 = get_val_for_set();
+      return this->ToString<T>(ret1);
+    };
+    T ret2;
+    CHECK(FromString<T>(GetOrSet(key, do_get_val_for_set), ret2));
+    return ret2;
+  }
+
+  // Implements an atomic update or set.
+  std::string UpdateOrSet(const std::string &key,
+                          std::function<std::string(const std::string *)> update_val);
+
+  template <typename T, typename C>
+  inline T UpdateOrSet(const std::string &key, C update_val) {
+    auto do_update_val = [this, &update_val] (const std::string *sval) {
+      T val;
+      const T *val_ptr = nullptr;
+      if (val != nullptr) {
+        CHECK(FromString<T>(sval, val));
+        val_ptr = &val;
+        return this->ToString<T>(update_val(val_ptr));
+      }
+    };
+    T ret;
+    CHECK(FromString<T>(UpdateOrSet(key, do_update_val), ret));
+    return ret;
+  }
+
+  template <typename T>
+  inline bool TryGet(const std::string &key, T *val) {
+    std::string data;
+    if (TryGetImpl(key, &data)) {
+      LOG_IF(FATAL, !this->FromString<T>(data, *val))
+          << "Unable to decode data for key '" << key << "'";
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  template <typename T>
+  inline void Set(const std::string &key, T &val) {
+    SetImpl(key, this->ToString<T>(val));
+  }
+
+  // Invoke a callback for each key/value pair.
+  void MatchAll(
+      std::function<bool(const std::string &, const std::string &)> cb);
+
+  template <typename T>
+  inline void MatchAll(
+      std::function<bool(const std::string &, T &)> cb) {
+    std::function<bool(const std::string &, const std::string &)> adaptor =
+        [&] (const std::string &key, const std::string &val_str) -> bool{
+          T val;
+          CHECK(FromString<T>(val_str, val));
+          return cb(key, val);
+        };
+    return MatchAll(adaptor);
+  }
+
+  // Invoke a callback for each key/value pair, where all the keys share a
+  // common prefix.
+  void MatchCommonPrefix(
+      const std::string &key_prefix_,
+      std::function<bool(const std::string &, const std::string &)> cb);
+
+  template <typename T>
+  inline void MatchCommonPrefix(
+      const std::string &key_prefix_,
+      std::function<bool(const std::string &, T &)> cb) {
+    std::function<bool(const std::string &, const std::string &)> adaptor =
+        [&] (const std::string &key, const std::string &val_str) -> bool{
+          T val;
+          CHECK(FromString<T>(val_str, val));
+          return cb(key, val);
+        };
+    return MatchCommonPrefix(key_prefix_, adaptor);
+  }
+
+  // Given a `search_key` of length N, invoke a callback for each key/value
+  // pair (key,value) such that
+  //   1. `key` has the prefix HI:LO: where HI and LO are strings also of
+  //      length N, and
+  //   2. it holds that HI >= search_key >= LO lexicographically.
+  void MatchRangesContainingKey(
+      const std::string &search_key,
+      std::function<bool(std::string_view low,
+                         std::string_view high,
+                         std::string_view key_suffix,
+                         std::string_view value)> cb);
+
+  class KeyValueEngine;
+
+ private:
+  KeyValueStore(void) = delete;
+
+  template <typename T>
+  inline static std::string ToString(const T &data) {
+    if constexpr (std::is_base_of_v<google::protobuf::Message, T>) {
+      std::string ret;
+      CHECK(data.AppendToString(&ret));
+      return ret;
+    } else if constexpr (std::is_convertible_v<T, std::string>) {
+      return data;
+    } else if constexpr (std::is_scalar_v<T>) {
+      std::stringstream ss;
+      CHECK(ss << data);
+      return ss.str();
+    } else {
+      static_assert(std::is_same_v<T, void>);
+    }
+  }
+
+  template <typename T>
+  inline static bool FromString(const std::string &data, T &out) {
+    if constexpr (std::is_base_of_v<google::protobuf::Message, T>) {
+      return out.ParseFromString(data);
+    } else if constexpr (std::is_same_v<std::string, T>) {
+      out = data;
+      return true;
+    } else if constexpr (std::is_scalar_v<T>) {
+      std::stringstream ss;
+      CHECK(ss << data);
+      if (ss >> out) {
+        return ss.eof();
+      } else {
+        return false;
+      }
+    } else {
+      static_assert(std::is_same_v<T, void>);
+    }
+  }
+
+  // Try to get the value associated with `key` in the store. If the value
+  // exists, then `val` is updated, and `true` is returned. Otherwise `false`
+  // is returned.
+  bool TryGetImpl(const std::string &key, std::string *val);
+
+  // Set the value associated with `key` in the store to `val`.
+  void SetImpl(const std::string &key, const std::string &val);
+
+  std::shared_ptr<KeyValueEngine> engine;
+  const std::string key_prefix;
+};
+
+}  // namespace mu


### PR DESCRIPTION
The changes moves the key value store from the old multiplier and fixes the issues with llvm13.