### PR TITLE
Avoid re-defining gflags (and a few other) symbols in the examples.

### DIFF
--- a/bin/Examples/FindSymbol.cpp
+++ b/bin/Examples/FindSymbol.cpp
@@ -12,8 +12,8 @@
 #include "Index.h"
 
 DECLARE_bool(help);
-DEFINE_string(host, "localhost", "Hostname of mx-server. Use 'unix' for a UNIX domain socket.");
-DEFINE_string(port, "50051", "Port of mx-server. Use a path and 'unix' for the host for a UNIX domain socket.");
+DECLARE_string(host);
+DECLARE_string(port);
 DEFINE_string(name, "", "Search for the symbol with name");
 
 extern "C" int main(int argc, char *argv[]) {

--- a/bin/Examples/ListFiles.cpp
+++ b/bin/Examples/ListFiles.cpp
@@ -12,8 +12,8 @@
 #include <sstream>
 
 DECLARE_bool(help);
-DEFINE_string(host, "localhost", "Hostname of mx-server. Use 'unix' for a UNIX domain socket.");
-DEFINE_string(port, "50051", "Port of mx-server. Use a path and 'unix' for the host for a UNIX domain socket.");
+DECLARE_string(host);
+DECLARE_string(port);
 
 extern "C" int main(int argc, char *argv[]) {
   std::stringstream ss;

--- a/bin/Examples/ListFragments.cpp
+++ b/bin/Examples/ListFragments.cpp
@@ -12,8 +12,8 @@
 #include <sstream>
 
 DECLARE_bool(help);
-DEFINE_string(host, "localhost", "Hostname of mx-server. Use 'unix' for a UNIX domain socket.");
-DEFINE_string(port, "50051", "Port of mx-server. Use a path and 'unix' for the host for a UNIX domain socket.");
+DECLARE_string(host);
+DECLARE_string(port);
 DEFINE_uint64(file_id, 0, "ID of the file from which to print fragments.");
 
 extern "C" int main(int argc, char *argv[]) {

--- a/bin/Examples/ListVariables.cpp
+++ b/bin/Examples/ListVariables.cpp
@@ -12,15 +12,15 @@
 #include <sstream>
 
 DECLARE_bool(help);
-DEFINE_string(host, "localhost", "Hostname of mx-server. Use 'unix' for a UNIX domain socket.");
-DEFINE_string(port, "50051", "Port of mx-server. Use a path and 'unix' for the host for a UNIX domain socket.");
+DECLARE_string(host);
+DECLARE_string(port);
 DEFINE_uint64(fragment_id, 0, "ID of the fragment from which to print variable names");
 DEFINE_uint64(file_id, 0, "ID of the file from which to print variable names");
 //DEFINE_bool(list_variables, false, "Should we list the variables inside of functions?");
 DEFINE_bool(show_locations, false, "Show the file locations of the variable?");
 
-std::unordered_map<mx::RawEntityId, std::filesystem::path> file_paths;
-mx::FileLocationCache location_cache;
+extern std::unordered_map<mx::RawEntityId, std::filesystem::path> file_paths;
+extern mx::FileLocationCache location_cache;
 
 static void PrintVariableNames(mx::Fragment fragment) {
   for (mx::VarDecl var : mx::VarDecl::in(fragment)) {

--- a/bin/Examples/PrintFile.cpp
+++ b/bin/Examples/PrintFile.cpp
@@ -12,8 +12,8 @@
 #include <sstream>
 
 DECLARE_bool(help);
-DEFINE_string(host, "localhost", "Hostname of mx-server. Use 'unix' for a UNIX domain socket.");
-DEFINE_string(port, "50051", "Port of mx-server. Use a path and 'unix' for the host for a UNIX domain socket.");
+DECLARE_string(host);
+DECLARE_string(port);
 DEFINE_uint64(file_id, 0, "ID of the file to print");
 
 extern "C" int main(int argc, char *argv[]) {

--- a/bin/Examples/PrintSourceIR.cpp
+++ b/bin/Examples/PrintSourceIR.cpp
@@ -12,8 +12,8 @@
 #include <sstream>
 
 DECLARE_bool(help);
-DEFINE_string(host, "localhost", "Hostname of mx-server. Use 'unix' for a UNIX domain socket.");
-DEFINE_string(port, "50051", "Port of mx-server. Use a path and 'unix' for the host for a UNIX domain socket.");
+DECLARE_string(host);
+DECLARE_string(port);
 DEFINE_uint64(fragment_id, 0, "ID of the fragment to print");
 
 extern "C" int main(int argc, char *argv[]) {

--- a/bin/Examples/RegexQuery.cpp
+++ b/bin/Examples/RegexQuery.cpp
@@ -15,8 +15,8 @@
 #include <sstream>
 
 DECLARE_bool(help);
-DEFINE_string(host, "localhost", "Hostname of mx-server. Use 'unix' for a UNIX domain socket.");
-DEFINE_string(port, "50051", "Port of mx-server. Use a path and 'unix' for the host for a UNIX domain socket.");
+DECLARE_string(host);
+DECLARE_string(port);
 DEFINE_string(query, "", "Query pattern to be searched");
 DEFINE_uint64(fragment_id, 0, "ID of the fragment in which to perform the search");
 

--- a/bin/Examples/WeggliQuery.cpp
+++ b/bin/Examples/WeggliQuery.cpp
@@ -16,8 +16,8 @@
 
 DECLARE_bool(help);
 DEFINE_bool(c_plus_plus, false, "Should we interpret the query as C++ code?ß");
-DEFINE_string(host, "localhost", "Hostname of mx-server. Use 'unix' for a UNIX domain socket.");
-DEFINE_string(port, "50051", "Port of mx-server. Use a path and 'unix' for the host for a UNIX domain socket.");
+DECLARE_string(host);
+DECLARE_string(port);
 DEFINE_string(query, "", "Query pattern to be searched");
 DEFINE_bool(print_matches, false, "Print variable matches found for the syntax");
 


### PR DESCRIPTION
This allows linking with mold which complains about duplicate symbols otherwise.