### PR TITLE
Include <assert.h> in lib/API/Weggli.cpp

### DIFF
--- a/lib/API/Weggli.cpp
+++ b/lib/API/Weggli.cpp
@@ -4,9 +4,9 @@
 // This source code is licensed in accordance with the terms specified in
 // the LICENSE file found in the root directory of this source tree.
 
-# include <assert.h>
-
 #include "Weggli.h"
+
+#include <cassert>
 
 #include "Fragment.h"
 


### PR DESCRIPTION
Fix missing header.