### PR TITLE
Expose `tokens()` API for mx::Type

### DIFF
--- a/include/multiplier/AST.h
+++ b/include/multiplier/AST.h
@@ -30467,6 +30467,7 @@ class Type {
   Type with_restrict(void) const;
   Type with_volatile(void) const;
   Type without_local_fast_qualifiers(void) const;
+  TokenRange tokens(void) const;
 };
 
 using TemplateTypeParmTypeRange = DerivedEntityRange<TypeIterator, TemplateTypeParmType>;

--- a/lib/API/AST.cpp
+++ b/lib/API/AST.cpp
@@ -18283,6 +18283,11 @@ Type Type::without_local_fast_qualifiers(void) const {
   return fragment->TypeFor(fragment, id, false).value();
 }
 
+TokenRange Type::tokens(void) const {
+  auto self = fragment->NthType(offset_);
+  return fragment->TokenRangeFor(fragment, self.getVal5(), self.getVal6());
+}
+
 std::optional<TemplateTypeParmType> TemplateTypeParmType::from(const TokenContext &c) {
   return from(c.as_type());
 }


### PR DESCRIPTION
Probably not the way to do it, but Syntex requires an API like this.