### PR TITLE
Ensure that the transitive dependencies of mx-util are properly exposed

### DIFF
--- a/lib/Util/CMakeLists.txt
+++ b/lib/Util/CMakeLists.txt
@@ -58,13 +58,13 @@ target_compile_definitions("mx-util"
 target_link_libraries("mx-util"
   PUBLIC
     "mx-common"
+    "glog::glog"
     $<BUILD_INTERFACE:concurrentqueue>
-    $<BUILD_INTERFACE:glog::glog>
     $<BUILD_INTERFACE:gflags::gflags>
     $<BUILD_INTERFACE:SQLite::SQLite3>
   PRIVATE
     $<BUILD_INTERFACE:reproc++>
-    $<BUILD_INTERFACE:RocksDB::rocksdb>
+    "RocksDB::rocksdb"
 )
 
 set_target_properties("mx-util"

--- a/multiplierConfig.cmake.in
+++ b/multiplierConfig.cmake.in
@@ -27,6 +27,14 @@ if(NOT TARGET @PROJECT_NAME@::mx-api)
     find_package(re2 CONFIG REQUIRED)
   endif()
 
+  if(NOT TARGET glog::glog)
+    find_package(glog REQUIRED)
+  endif()
+
+  if(NOT TARGET RocksDB::rocksdb)
+    find_package(RocksDB REQUIRED)
+  endif()
+
   if(MX_ENABLE_WEGGLI AND NOT TARGET weggli_native::static)
     find_package(weggli_native CONFIG REQUIRED)
   endif()


### PR DESCRIPTION
Previously clients linking against mx-util such as syntex had to manually
pull in glog and RocksDB, this patch ensures that this is no longer necessary.