### PR TITLE
Create database in main and pass the reference to global state

### DIFF
--- a/bin/Index/Context.cpp
+++ b/bin/Index/Context.cpp
@@ -24,11 +24,11 @@
 
 namespace indexer {
 
-GlobalIndexingState::GlobalIndexingState(std::filesystem::path db_path,
+GlobalIndexingState::GlobalIndexingState(mx::DatabaseWriter &database_,
                                  const Executor &exe_)
     : num_workers(exe_.NumWorkers()),
       executor(exe_),
-      database(std::move(db_path)) {}
+      database(database_) {}
 
 GlobalIndexingState::~GlobalIndexingState(void) {}
 

--- a/bin/Index/Context.h
+++ b/bin/Index/Context.h
@@ -67,9 +67,9 @@ class GlobalIndexingState {
   CodeGenerator codegen;
 
   // Write access to the index database.
-  mx::DatabaseWriter database;
+  mx::DatabaseWriter &database;
 
-  explicit GlobalIndexingState(std::filesystem::path db_path,
+  explicit GlobalIndexingState(mx::DatabaseWriter &database_,
                                const Executor &exe_);
 
   ~GlobalIndexingState(void);

--- a/bin/Index/Main.cpp
+++ b/bin/Index/Main.cpp
@@ -135,7 +135,8 @@ extern "C" int main(int argc, char *argv[], char *envp[]) {
   }
 
   indexer::Executor executor{{FLAGS_num_workers}};
-  auto ic = std::make_shared<indexer::GlobalIndexingState>(FLAGS_db, executor);
+  mx::DatabaseWriter database(FLAGS_db);
+  auto ic = std::make_shared<indexer::GlobalIndexingState>(database, executor);
   auto fs = pasta::FileSystem::CreateNative();
   pasta::FileManager fm(fs);
 

--- a/include/multiplier/Database.h
+++ b/include/multiplier/Database.h
@@ -269,7 +269,7 @@ struct ReferenceRecord {
     m(ReferenceRecord) \
     m(SymbolNameRecord)
 
-#define MX_DATABASE_PRAGMA_SYNCHRONOUS "OFF"
+#define MX_DATABASE_PRAGMA_SYNCHRONOUS "NORMAL"
 #define MX_DATABASE_TEMP_STORE "MEMORY"
 #define MX_DATABASE_JOURNAL_MODE "WAL"
 

--- a/lib/Database.cpp
+++ b/lib/Database.cpp
@@ -387,6 +387,7 @@ sqlite::Connection CreateDatabase(const std::filesystem::path &db_path_) {
         "  PRIMARY KEY(file_token_id, hash)"
         ") WITHOUT rowid");
   }
+
   return db;
 }
 

--- a/lib/SQLiteStore.cpp
+++ b/lib/SQLiteStore.cpp
@@ -320,8 +320,8 @@ Statement Connection::Prepare(const std::string &query) {
       impl->db, query.c_str(), static_cast<int>(query.size()),
       SQLITE_PREPARE_PERSISTENT, &stmt, const_cast<const char **>(&tail));
   if (SQLITE_OK != ret) {
-    assert(false);
-    throw Error("Failed to prepare statement");
+    std::string error_msg = sqlite3_errmsg(impl->db) == nullptr ? "" : sqlite3_errmsg(impl->db);
+    throw Error("Failed to prepare statement " + error_msg);
   }
 
   impl->stmts.push_back(stmt);


### PR DESCRIPTION
The changes move the database creation to main and pass it to global indexing state. It also update the database sync mode to NORMAL that is safer in WAL journaling mode. 