### PR TITLE
Refactor package dependency

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -209,15 +209,15 @@ add_dependencies("mx-api"
 
 target_link_libraries("mx-api"
   PUBLIC
-    "CapnProto::capnp-rpc"
     "mx-sqlite"
     "gap::gap"
     "gap::gap-core"
     "std::coroutines"
     "gap::gap-settings"
   PRIVATE
+    "CapnProto::capnp-rpc"
     $<BUILD_INTERFACE:concurrentqueue>
-    $<IF:$<TARGET_EXISTS:zstd::libzstd_static>,zstd::libzstd_static,zstd::libzstd_shared>
+    $<BUILD_INTERFACE:$<IF:$<TARGET_EXISTS:zstd::libzstd_static>,zstd::libzstd_static,zstd::libzstd_shared>>
 )
 
 if(MX_ENABLE_VAST)

--- a/multiplierConfig.cmake.in
+++ b/multiplierConfig.cmake.in
@@ -21,20 +21,12 @@ if(NOT TARGET @PROJECT_NAME@::mx-api)
     find_package(CapnProto CONFIG REQUIRED)
   endif()
 
-  if(NOT TARGET zstd::libzstd_shared AND NOT TARGET zstd::libzstd_static)
-    find_package(zstd CONFIG REQUIRED)
-  endif()
-
   if(MX_ENABLE_RE2 AND NOT TARGET re2::re2)
     find_package(re2 CONFIG REQUIRED)
   endif()
 
   if(NOT TARGET glog::glog)
     find_package(glog REQUIRED)
-  endif()
-
-  if(NOT TARGET SQLite3::SQLite)
-    find_package(SQLite3 3.35 REQUIRED)
   endif()
 
   if(NOT TARGET gap::gap)


### PR DESCRIPTION
PR removes find_package for zstd and SQLite3, move zstd as build interface and capnproto as private. 