### PR TITLE
Add zstd dependency instead of vendoring in

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -217,7 +217,7 @@ target_link_libraries("mx-api"
   PRIVATE
     "CapnProto::capnp-rpc"
     $<BUILD_INTERFACE:concurrentqueue>
-    $<BUILD_INTERFACE:$<IF:$<TARGET_EXISTS:zstd::libzstd_static>,zstd::libzstd_static,zstd::libzstd_shared>>
+    $<IF:$<TARGET_EXISTS:zstd::libzstd_static>,zstd::libzstd_static,zstd::libzstd_shared>
 )
 
 if(MX_ENABLE_VAST)

--- a/multiplierConfig.cmake.in
+++ b/multiplierConfig.cmake.in
@@ -21,6 +21,10 @@ if(NOT TARGET @PROJECT_NAME@::mx-api)
     find_package(CapnProto CONFIG REQUIRED)
   endif()
 
+  if(NOT TARGET zstd::libzstd_shared AND NOT TARGET zstd::libzstd_static)
+    find_package(zstd CONFIG REQUIRED)
+  endif()
+
   if(MX_ENABLE_RE2 AND NOT TARGET re2::re2)
     find_package(re2 CONFIG REQUIRED)
   endif()


### PR DESCRIPTION
The PR changes adds zstd as target dependencies instead of vendoring in the package. zstd is one of the target link libraries of LLVMSupport and vendoring in will not help much unless we create an alias for zstd(mx-zstd). It will always gets pickup from the cxx-common build.
```
set_target_properties(LLVMSupport PROPERTIES
  INTERFACE_LINK_LIBRARIES "m;z3::libz3;ZLIB::ZLIB;zstd::libzstd_static;LLVMDemangle"
)
```
The better solution is to include them in the package (similar to RE2 & capnproto) if needed. 