### PR TITLE
Update `mx-mlir` target link libraries 

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -40,24 +40,29 @@ if(MX_ENABLE_VAST)
       vast::MLIRLowLevel
       vast::MLIRHighLevel
       MLIRDialect
-      MLIRMLProgramDialect
-      MLIROpenMPDialect
-      MLIRTosaDialect
-  
-      MLIRBufferizationTransformOps
-      MLIRSparseTensorTransforms
-      MLIROpenACCDialect
-      MLIRLLVMIRTransforms
-      MLIRROCDLDialect
-      MLIRAsyncDialect
-      MLIRSCFTransformOps
-      MLIREmitCDialect
-      MLIRNVGPUDialect
-      MLIRShapeDialect
       MLIRAMDGPUDialect
-      MLIRShapeOpsTransforms
-      MLIRLinalgTransformOps
+      MLIRAsyncDialect
+      MLIREmitCDialect
+      MLIRIndexDialect
+      MLIRMLProgramDialect
+      MLIRNVGPUDialect
+      MLIROpenACCDialect
+      MLIROpenMPDialect
+      MLIRROCDLDialect
+      MLIRShapeDialect
       MLIRSPIRVDialect
+      MLIRTosaDialect
+
+      MLIRLLVMIRTransforms
+      MLIRShapeOpsTransforms
+      MLIRSparseTensorTransforms
+      MLIRAffineTransformOps
+      MLIRBufferizationTransformOps
+      MLIRGPUTransformOps
+      MLIRLinalgTransformOps
+      MLIRMemRefTransformOps
+      MLIRSCFTransformOps
+      MLIRVectorTransformOps
       MLIRTensorInferTypeOpInterfaceImpl
   )
 else(MX_ENABLE_VAST)


### PR DESCRIPTION
Update `mx-mlir` target link libraries to build SourceIR integration with llvm16