### PR TITLE
Move the tokentree api into analysis to make it easier to change late…

### DIFF
--- a/bin/Examples/PrintFragment.cpp
+++ b/bin/Examples/PrintFragment.cpp
@@ -10,6 +10,7 @@
 
 #include "Index.h"
 #include <multiplier/AST.h>
+#include <multiplier/Analysis/TokenTree.h>
 
 DEFINE_uint64(fragment_id, 0, "ID of the fragment to print");
 DEFINE_bool(unparsed, false, "Show original source code?");
@@ -32,18 +33,14 @@ extern "C" int main(int argc, char *argv[]) {
     return EXIT_FAILURE;
   }
 
-  mx::TokenTree tt = mx::TokenTree::from(mx::File::containing(fragment.value()).value());
-
-  for (mx::Token t : tt.serialize()) {
-    std::cout << t.data();
-  }
-
-  std::cout << '\n';
-  return 0;
-
   // Print our the tokens of this fragment as they appear in the file.
   if (FLAGS_unparsed) {
-    RenderFragment(std::cout, *fragment, mx::TokenRange(), "", true);
+    std::cout << "Unparsed data from token tree:\n";
+
+    mx::TokenTree tt = mx::TokenTree::from(fragment.value());
+    for (mx::Token t : tt.serialize()) {
+      std::cout << t.data();
+    }
 
   // Print out the tokens of this fragment that were actually parsed. These
   // are post-macro expansion tokens, and generally don't include whitespace

--- a/include/multiplier/Analysis/TokenTree.h
+++ b/include/multiplier/Analysis/TokenTree.h
@@ -1,0 +1,49 @@
+// Copyright (c) 2023-present, Trail of Bits, Inc.
+// All rights reserved.
+//
+// This source code is licensed in accordance with the terms specified in
+// the LICENSE file found in the root directory of this source tree.
+
+
+#include "../Token.h"
+
+namespace mx {
+
+class TokenTreeVisitor {
+ public:
+  virtual ~TokenTreeVisitor(void) = default;
+
+  // Return `true` if the input substitution should be expanded or not.
+  virtual bool should_expand(const MacroSubstitution &) const;
+
+  // Return `true` if the input `__VA_OPT__` should be expanded or not.
+  virtual bool should_expand(const MacroVAOpt &) const;
+
+  // Choose which fragment to show.
+  virtual Fragment choose(const std::vector<Fragment> &) const;
+};
+
+// A tree of tokens, which can represent the variability of overlapping
+// fragments, macro expansions, etc., allowing one to render the tree down
+// into a singular linear range of tokens.
+class TokenTree {
+ private:
+  friend class File;
+  friend class Fragment;
+
+  std::shared_ptr<TokenTreeImpl> impl;
+
+  inline TokenTree(std::shared_ptr<TokenTreeImpl> impl_)
+      : impl(std::move(impl_)) {}
+
+ public:
+  TokenTree(void);
+
+  static TokenTree from(const File &);
+  static TokenTree from(const Fragment &);
+
+  // Serialize the token tree into a linear range.
+  TokenRange serialize(const TokenTreeVisitor &vis=TokenTreeVisitor()) const;
+};
+
+}  // namespace mx

--- a/include/multiplier/File.h
+++ b/include/multiplier/File.h
@@ -144,6 +144,9 @@ class File {
   // Go through the tokens of the iterator and return the first file found.
   static std::optional<File> containing(const TokenRange &tokens);
 
+  // Return the file containing the token tree.
+  static std::optional<File> containing(const TokenTree &tokens);
+
   inline static constexpr EntityCategory entity_category(void) {
     return EntityCategory::FILE;
   }

--- a/include/multiplier/Fragment.h
+++ b/include/multiplier/Fragment.h
@@ -84,6 +84,9 @@ class Fragment {
   static Fragment containing(const WeggliQueryMatch &);
   static Fragment containing(const RegexQueryMatch &);
 
+  // Return the fragment containing a token tree.
+  static std::optional<Fragment> containing(const TokenTree &);
+
   inline static Fragment containing(const Fragment &fragment) {
     return fragment;
   }

--- a/include/multiplier/Token.h
+++ b/include/multiplier/Token.h
@@ -44,7 +44,7 @@ class SimpleToken;  // Defined in Index.h due to `VariantEntity`.
 using CustomToken = std::variant<SimpleToken, Token>;
 
 // A single token, e.g. from a file or from a macro expansion.
-class Token {
+class Token final {
  private:
   friend class EntityProvider;
   friend class File;
@@ -315,38 +315,6 @@ class TokenRange {
 
   // Strip leading and trailing whitespace.
   TokenRange strip_whitespace(void) const noexcept;
-};
-
-class TokenTreeVisitor {
- public:
-  virtual ~TokenTreeVisitor(void) = default;
-
-  // Return `true` if the input substitution should be expanded or not.
-  virtual bool should_expand(const MacroSubstitution &) const;
-
-  // Return `true` if the input `__VA_OPT__` should be expanded or not.
-  virtual bool should_expand(const MacroVAOpt &) const;
-
-  // Choose which fragment to show.
-  virtual Fragment choose(const std::vector<Fragment> &) const;
-};
-
-// A tree of tokens, which can represent the variability of overlapping
-// fragments, macro expansions, etc., allowing one to render the tree down
-// into a singular linear range of tokens.
-class TokenTree {
- private:
-  std::shared_ptr<TokenTreeImpl> impl;
-
-  inline TokenTree(std::shared_ptr<TokenTreeImpl> impl_)
-      : impl(std::move(impl_)) {}
-
- public:
-  static TokenTree from(const File &);
-  static TokenTree from(const Fragment &);
-
-  // Serialize the token tree into a linear range.
-  TokenRange serialize(const TokenTreeVisitor &vis=TokenTreeVisitor()) const;
 };
 
 }  // namespace mx

--- a/lib/Analysis/CMakeLists.txt
+++ b/lib/Analysis/CMakeLists.txt
@@ -9,14 +9,16 @@
 set(source_include_dir "${PROJECT_SOURCE_DIR}/include/multiplier/Analysis")
 
 set(analysis_headers
-  "${source_include_dir}/Taint.h"
   "${source_include_dir}/IRAnalysis.h"
+  "${source_include_dir}/Taint.h"
+  "${source_include_dir}/TokenTree.h"
 )
 
 add_library("mx-analysis" STATIC
   "${analysis_headers}"
-  "Taint.cpp"
   "IRAnalysis.cpp"
+  "Taint.cpp"
+  "TokenTree.cpp"
 )
 
 target_link_libraries("mx-analysis"

--- a/lib/Analysis/TokenTree.cpp
+++ b/lib/Analysis/TokenTree.cpp
@@ -4,6 +4,8 @@
 // This source code is licensed in accordance with the terms specified in
 // the LICENSE file found in the root directory of this source tree.
 
+#include <multiplier/Analysis/TokenTree.h>
+
 #include <algorithm>
 #include <deque>
 #include <functional>
@@ -17,9 +19,9 @@
 #include <unordered_map>
 #include <vector>
 
-#include "File.h"
-#include "Fragment.h"
-#include "Token.h"
+#include "../File.h"
+#include "../Fragment.h"
+#include "../Token.h"
 
 //#define D(...) __VA_ARGS__
 #ifndef D
@@ -1103,6 +1105,12 @@ Fragment TokenTreeVisitor::choose(const std::vector<Fragment> &frags) const {
   return frags.front();
 }
 
+static const std::shared_ptr<TokenTreeImpl> kInvalidTree =
+    std::make_shared<TokenTreeImpl>();
+
+TokenTree::TokenTree(void)
+    : TokenTree(kInvalidTree) {}
+
 TokenTree TokenTree::from(const File &file) {
   auto self = std::make_shared<TokenTreeImpl>();
   auto file_tokens = file.tokens();
@@ -1384,6 +1392,26 @@ TokenRange TokenTree::serialize(const TokenTreeVisitor &vis) const {
   reader->data_hash = kHasher(reader->data);
 
   return TokenRange(std::move(reader), 0u, num_tokens);
+}
+
+// Return the file containing the token tree.
+std::optional<File> File::containing(const TokenTree &tree) {
+  if (tree.impl->file) {
+    return File(tree.impl->file);
+  } else if (tree.impl->fragment) {
+    return File::containing(Fragment(tree.impl->fragment));
+  } else {
+    return std::nullopt;
+  }
+}
+
+// Return the fragment containing a token tree.
+std::optional<Fragment> Fragment::containing(const TokenTree &tree) {
+  if (tree.impl->fragment) {
+    return Fragment(tree.impl->fragment);
+  } else {
+    return std::nullopt;
+  }
 }
 
 }  // namespace mx

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -192,7 +192,6 @@ add_library("mx-api" STATIC
   "ThreadLocal.h"
   "TokenContext.cpp"
   "Token.cpp"
-  "TokenTree.cpp"
   "Token.h"
   "Type.h"
   "Type.cpp"

--- a/lib/File.cpp
+++ b/lib/File.cpp
@@ -207,6 +207,11 @@ std::optional<File> File::containing(const Token &token) {
 
 // Go through the tokens of the iterator and return the first file found.
 std::optional<File> File::containing(const TokenRange &tokens) {
+  for (Token tok : tokens.file_tokens()) {
+    if (auto file = File::containing(tok)) {
+      return file;
+    }
+  }
   for (Token tok : tokens) {
     if (auto file = File::containing(tok)) {
       return file;


### PR DESCRIPTION
…r without triggering so many recompiles. Make it possible to get the file and fragment from the token tree.