### PR TITLE
This fixes a sigsegv in labelling references.

### DIFF
--- a/bin/Index/EntityMapper.cpp
+++ b/bin/Index/EntityMapper.cpp
@@ -263,7 +263,7 @@ mx::RawEntityId EntityMapper::EntityIdOfType(
 std::optional<const pasta::Decl> EntityMapper::ParentDecl(
     const pasta::AST &ast, const pasta::Decl &entity) const {
   if (auto it = parent_decls.find(entity.RawDecl());
-      it != parent_decls.end()) {
+      it != parent_decls.end() && it->second) {
     return ast.Adopt(static_cast<const clang::Decl *>(it->second));
   }
   return std::nullopt;
@@ -272,7 +272,7 @@ std::optional<const pasta::Decl> EntityMapper::ParentDecl(
 std::optional<const pasta::Decl> EntityMapper::ParentDecl(
     const pasta::AST &ast, const pasta::Stmt &entity) const {
   if (auto it = parent_decls.find(entity.RawStmt());
-      it != parent_decls.end()) {
+      it != parent_decls.end() && it->second) {
     return ast.Adopt(static_cast<const clang::Decl *>(it->second));
   }
   return std::nullopt;
@@ -281,7 +281,7 @@ std::optional<const pasta::Decl> EntityMapper::ParentDecl(
 std::optional<const pasta::Stmt> EntityMapper::ParentStmt(
     const pasta::AST &ast, const pasta::Decl &entity) const {
   if (auto it = parent_stmts.find(entity.RawDecl());
-      it != parent_stmts.end()) {
+      it != parent_stmts.end() && it->second) {
     return ast.Adopt(static_cast<const clang::Stmt *>(it->second));
   }
   return std::nullopt;
@@ -290,7 +290,7 @@ std::optional<const pasta::Stmt> EntityMapper::ParentStmt(
 std::optional<const pasta::Stmt> EntityMapper::ParentStmt(
     const pasta::AST &ast, const pasta::Stmt &entity) const {
   if (auto it = parent_stmts.find(entity.RawStmt());
-      it != parent_stmts.end()) {
+      it != parent_stmts.end() && it->second) {
     return ast.Adopt(static_cast<const clang::Stmt *>(it->second));
   }
   return std::nullopt;


### PR DESCRIPTION
The issue manifested as a result of the way parents were labelled. The backup parent labellers only set up the IDs, but not the pointers, and so nullptrs were being inserted into the parent_decls/stmts maps, leading to AST::Adopt on nullptrs in the reference labelling code.