### PR TITLE
Refactor to references. 

### DIFF
--- a/include/multiplier/Compilation.h
+++ b/include/multiplier/Compilation.h
@@ -150,6 +150,9 @@ class Compilation {
   // on macOS.
   gap::generator<std::pair<IncludePathLocation, std::filesystem::path>>
   framework_directories(void) const & noexcept;
+
+  // References to this compilation.
+  gap::generator<Reference> references(void) const &;
 };
 
 }  // namespace mx

--- a/include/multiplier/Index.h
+++ b/include/multiplier/Index.h
@@ -212,6 +212,7 @@ class Index {
 template <typename T>
 std::optional<T> Reference::as(void) const noexcept {
   constexpr EntityCategory c = T::static_category();
+  auto category_ = category();
   if constexpr (EntityCategory::NOT_AN_ENTITY == c) {
     return std::nullopt;
 

--- a/include/multiplier/Reference.h
+++ b/include/multiplier/Reference.h
@@ -19,15 +19,13 @@ class Index;
 class EntityProvider;
 class Reference;
 class ReferenceKindImpl;
-class ReferenceContextImpl;
 
 using OpaqueImplPtr = std::shared_ptr<const void>;
 using ReferenceKindImplPtr = std::shared_ptr<const ReferenceKindImpl>;
 using WeakReferenceKindImplPtr = std::weak_ptr<const ReferenceKindImpl>;
-using ReferenceContextImplPtr = std::shared_ptr<const ReferenceContextImpl>;
 
 enum class BuiltinReferenceKind {
-  USE, // default value as some kind of uses
+  USE,  // Default value as some kind of uses.
   ADDRESS_OF,
   ASSIGNED_TO,
   ASSIGNEMENT,
@@ -49,8 +47,10 @@ inline static const char *EnumerationName(BuiltinReferenceKind) {
   return "BuiltinReferenceKind";
 }
 
+const char *EnumeratorName(BuiltinReferenceKind);
+
 inline static constexpr unsigned NumEnumerators(BuiltinReferenceKind) {
-  return 26;
+  return 16;
 }
 
 class ReferenceKind {
@@ -70,8 +70,8 @@ class ReferenceKind {
   // Get or create a reference kind.
   static ReferenceKind get(const Index &, std::string_view name);
 
-  // Was this reference added by the code?
-  bool is_explicit_code_reference(void) const noexcept;
+  // Is this a built-in reference kind?
+  std::optional<BuiltinReferenceKind> builtin_reference_kind(void) const noexcept;
 
   // The name of this reference kind.
   const std::string &kind(void) const & noexcept;
@@ -80,50 +80,13 @@ class ReferenceKind {
   std::string kind(void) const && noexcept;
 };
 
-class ReferenceContext {
- private:
-  ReferenceContextImplPtr impl;
-
-#define MX_FRIEND(type_name, lower_name, enum_name, category) \
-    friend class type_name;
-
-  MX_FOR_EACH_ENTITY_CATEGORY(MX_FRIEND,
-                              MX_FRIEND,
-                              MX_FRIEND,
-                              MX_FRIEND,
-                              MX_FRIEND,
-                              MX_FRIEND,
-                              MX_FRIEND)
-#undef MX_FRIEND
-
- public:
-  ReferenceContext(void) = delete;
-
-  inline explicit ReferenceContext(ReferenceContextImplPtr impl_)
-      : impl(std::move(impl_)) {}
-
-
-#define MX_DECLARE_REF_GETTER(type_name, lower_name, enum_name, category) \
-    std::optional<type_name> as_ ## lower_name (void) const noexcept;
-
-  MX_FOR_EACH_ENTITY_CATEGORY(MX_DECLARE_REF_GETTER,
-                              MX_DECLARE_REF_GETTER,
-                              MX_DECLARE_REF_GETTER,
-                              MX_DECLARE_REF_GETTER,
-                              MX_DECLARE_REF_GETTER,
-                              MX_DECLARE_REF_GETTER,
-                              MX_DECLARE_REF_GETTER)
-#undef MX_DECLARE_REF_GETTER
-};
-
 class Reference {
  private:
   OpaqueImplPtr impl;
   // The reference context will have entity id of referrer
   // that references the entity of interest.
-  ReferenceContextImplPtr context_;
-  RawEntityId eid;
-  EntityCategory category_;
+  RawEntityId context_id;
+  RawEntityId from_id;
   RawEntityId kind_id;
 
 #define MX_FRIEND(type_name, lower_name, enum_name, category) \
@@ -140,44 +103,52 @@ class Reference {
 
   Reference(void) = delete;
 
-  inline explicit Reference(OpaqueImplPtr impl_, ReferenceContextImplPtr context__,
-                            RawEntityId eid_, EntityCategory category__, RawEntityId kind_id_)
-      : impl(std::move(impl_)),
-        context_(std::move(context__)),
-        eid(eid_),
-        category_(category__),
-        kind_id(kind_id_) {}
-
   // Add a reference between two entities.
   static bool add(const ReferenceKind &kind, RawEntityId from_id,
                   RawEntityId to_id, RawEntityId context_id, int);
 
  public:
+
+  inline explicit Reference(OpaqueImplPtr impl_,
+                            RawEntityId context_id_,
+                            RawEntityId from_id_,
+                            RawEntityId kind_id_)
+      : impl(std::move(impl_)),
+        context_id(context_id_),
+        from_id(from_id_),
+        kind_id(kind_id_) {}
+
   // The context id will be same or ancestor of `from_id`. The default
   // value will be same as `from_id`.
-  inline static bool add(const ReferenceKind &kind, EntityId from_id,
-                         EntityId to_id, EntityId context_id) {
-    return add(kind, from_id.Pack(), to_id.Pack(), context_id.Pack(), 0);
+  inline static bool add(const ReferenceKind &kind, EntityId from_id_,
+                         EntityId to_id_, EntityId context_id_) {
+    return add(kind, from_id_.Pack(), to_id_.Pack(), context_id_.Pack(), 0);
   }
 
-  inline EntityCategory category(void) const noexcept {
-    return category_;
-  }
+  EntityCategory category(void) const noexcept;
 
-  // Was this reference added by the indexer?
-  inline bool is_explicit_code_reference(void) const noexcept {
-    return !kind_id;
+  // Is this a built-in reference kind?
+  inline std::optional<BuiltinReferenceKind>
+  builtin_reference_kind(void) const noexcept {
+    if (kind_id >= NumEnumerators(BuiltinReferenceKind{})) {
+      return std::nullopt;
+    }
+    return static_cast<BuiltinReferenceKind>(kind_id);
   }
 
   // The ID of the referenced entity.
   inline EntityId referenced_entity_id(void) const noexcept {
-    return eid;
+    return from_id;
   }
 
   // Return the kind of this reference.
   ReferenceKind kind(void) const noexcept;
 
-  std::optional<ReferenceContext> context(void) const noexcept;
+  // The contextual entity associated with this reference.
+  VariantEntity context(void) const noexcept;
+
+  // Generate all references to some kind of entity.
+  static gap::generator<Reference> to(const VariantEntity &entity);
 
   // Return this reference as a `VariantEntity`.
   VariantEntity as_variant(void) const noexcept;

--- a/lib/Attr.cpp
+++ b/lib/Attr.cpp
@@ -36,14 +36,7 @@ SpecificEntityId<AttrId> Attr::id(void) const {
 
 // Return references to this attribute.
 gap::generator<Reference> Attr::references(void) const & {
-  EntityProviderPtr ep = impl->ep;
-  for (auto ref : ep->References(ep, id().Pack())) {
-    if (auto [eptr, category] = ReferencedEntity(ep, std::get<0>(ref)); eptr) {
-      auto context = std::make_shared<ReferenceContextImpl>(ep, std::get<1>(ref));
-      co_yield Reference(std::move(eptr), std::move(context),
-                         std::get<0>(ref), category, std::get<2>(ref));
-    }
-  }
+  return References(impl->ep, id().Pack());
 }
 
 }  // namespace mx

--- a/lib/Compilation.cpp
+++ b/lib/Compilation.cpp
@@ -14,6 +14,7 @@
 #include "IR/SourceIR.h"
 #endif
 
+#include "Reference.h"
 #include "Token.h"
 
 namespace mx {
@@ -285,6 +286,11 @@ std::optional<ir::builtin::ModuleOp> Compilation::ir(void) const noexcept {
 #endif
 
   return std::nullopt;
+}
+
+// References to this compilation.
+gap::generator<Reference> Compilation::references(void) const & {
+  return References(impl->ep, id().Pack());
 }
 
 }  // namespace mx

--- a/lib/EntityProvider.h
+++ b/lib/EntityProvider.h
@@ -178,8 +178,8 @@ class EntityProvider {
   virtual gap::generator<RawEntityId> Redeclarations(
       const Ptr &, RawEntityId eid) & = 0;
 
-  // Fill out `redecl_ids_out` and `references_ids_out` with the set of things
-  // to analyze when looking for references.
+  // Generate references to `raw_id` as a tuple of `from_id`, `context_id`, and
+  // `kind_id`. Internally, this will handle redeclarations.
   virtual gap::generator<std::tuple<RawEntityId, RawEntityId, RawEntityId>>
   References(const Ptr &, RawEntityId eid) & = 0;
 

--- a/lib/File.cpp
+++ b/lib/File.cpp
@@ -314,14 +314,7 @@ std::string_view File::data(void) const noexcept {
 
 // References of this file.
 gap::generator<Reference> File::references(void) const & {
-  EntityProviderPtr ep = impl->ep;
-  for (auto ref : ep->References(ep, id().Pack())) {
-    if (auto [eptr, category] = ReferencedEntity(ep, std::get<0>(ref)); eptr) {
-      auto context = std::make_shared<ReferenceContextImpl>(ep, std::get<1>(ref));
-      co_yield Reference(std::move(eptr), std::move(context),
-                         std::get<0>(ref), category, std::get<2>(ref));
-    }
-  }
+  return References(impl->ep, id().Pack());
 }
 
 }  // namespace mx

--- a/lib/Fragment.cpp
+++ b/lib/Fragment.cpp
@@ -231,14 +231,7 @@ gap::generator<Fragment> Fragment::nested_fragments(void) const & {
 
 // Return references to this fragment.
 gap::generator<Reference> Fragment::references(void) const & {
-  auto ep = impl->ep;
-  for (auto ref : ep->References(ep, id().Pack())) {
-    if (auto [eptr, category] = ReferencedEntity(ep, std::get<0>(ref)); eptr) {
-      auto context = std::make_shared<ReferenceContextImpl>(ep, std::get<1>(ref));
-      co_yield Reference(std::move(eptr), std::move(context),
-                         std::get<0>(ref), category, std::get<2>(ref));
-    }
-  }
+  return References(impl->ep, id().Pack());
 }
 
 // Return the list of top-level macros in this fragment.

--- a/lib/Macro.cpp
+++ b/lib/Macro.cpp
@@ -67,14 +67,7 @@ gap::generator<Macro> Macro::containing_internal(const Token &token) {
 
 // References to this macro definition.
 gap::generator<Reference> Macro::references(void) const & {
-  const EntityProviderPtr &ep = impl->ep;
-  for (auto ref : ep->References(ep, id().Pack())) {
-    if (auto [eptr, category] = ReferencedEntity(ep, std::get<0>(ref)); eptr) {
-      auto context = std::make_shared<ReferenceContextImpl>(ep, std::get<1>(ref));
-      co_yield Reference(std::move(eptr), std::move(context),
-                         std::get<0>(ref), category, std::get<2>(ref));
-    }
-  }
+  return References(impl->ep, id().Pack());
 }
 
 namespace {

--- a/lib/Pseudo.cpp
+++ b/lib/Pseudo.cpp
@@ -28,14 +28,7 @@ namespace mx {
     } \
     \
     gap::generator<Reference> name::references(void) const & { \
-      EntityProviderPtr ep = impl->ep; \
-      for (auto ref : ep->References(ep, id().Pack())) { \
-        if (auto [eptr, category] = ReferencedEntity(ep, std::get<0>(ref)); eptr) { \
-          auto context = std::make_shared<ReferenceContextImpl>(ep, std::get<1>(ref)); \
-          co_yield Reference(std::move(eptr), std::move(context), \
-                             std::get<0>(ref), category, std::get<2>(ref)); \
-        } \
-      } \
+      return References(impl->ep, id().Pack()); \
     }
 
 MX_FOR_EACH_PSEUDO(MX_DEFINE_PSEUDO)

--- a/lib/Reference.h
+++ b/lib/Reference.h
@@ -24,17 +24,8 @@ class ReferenceKindImpl {
         kind_data(std::move(kind_data_)) {}
 };
 
-class ReferenceContextImpl {
- public:
-  const EntityProviderPtr ep;
-  const RawEntityId eid;
+gap::generator<Reference> EmptyReferences(void);
 
-  inline ReferenceContextImpl(EntityProviderPtr ep_, RawEntityId eid_)
-      : ep(std::move(ep_)),
-        eid(eid_) {}
-};
-
-std::pair<OpaqueImplPtr, EntityCategory> ReferencedEntity(
-    const EntityProviderPtr &ep, RawEntityId raw_id);
+gap::generator<Reference> References(EntityProviderPtr ep, RawEntityId raw_id);
 
 }  // namespace mx

--- a/lib/SQLiteEntityProvider.cpp
+++ b/lib/SQLiteEntityProvider.cpp
@@ -626,11 +626,8 @@ RawEntityIdList SQLiteEntityProvider::ReadRedeclarations(
   return ret;
 }
 
-// Fill out `redecl_ids_out` and `fragment_ids_out` with the set of things
-// to analyze when looking for references.
-//
-// NOTE(pag): `fragment_ids_out` will always contain the fragment associated
-//            with `eid` if `eid` resides in a fragment.
+// Generate references to `raw_id` as a tuple of `from_id`, `context_id`, and
+// `kind_id`. Internally, this will handle redeclarations.
 gap::generator<std::tuple<RawEntityId, RawEntityId, RawEntityId>>
 SQLiteEntityProvider::References(const Ptr &self, RawEntityId raw_id) & {
 

--- a/lib/Stmt.cpp
+++ b/lib/Stmt.cpp
@@ -31,14 +31,7 @@ SpecificEntityId<StmtId> Stmt::id(void) const {
 
 // References to this statement.
 gap::generator<Reference> Stmt::references(void) const & {
-  EntityProviderPtr ep = impl->ep;
-  for (auto ref : ep->References(ep, id().Pack())) {
-    if (auto [eptr, category] = ReferencedEntity(ep, std::get<0>(ref)); eptr) {
-      auto context = std::make_shared<ReferenceContextImpl>(ep, std::get<1>(ref));
-      co_yield Reference(std::move(eptr), std::move(context),
-                         std::get<0>(ref), category, std::get<2>(ref));
-    }
-  }
+  return References(impl->ep, id().Pack());
 }
 
 // Public methods for derived classes

--- a/lib/Token.cpp
+++ b/lib/Token.cpp
@@ -1126,7 +1126,6 @@ bool CustomTokenReader::Equals(const TokenReader *that_) const {
   return token_ids == that->token_ids;
 }
 
-
 const FragmentImpl *CustomTokenReader::OwningFragment(void) const noexcept {
   return fragment.get();
 }
@@ -1158,14 +1157,9 @@ EntityId Token::id(void) const {
 // References to this token.
 gap::generator<Reference> Token::references(void) const & {
   if (EntityProviderPtr ep = TokenReader::EntityProviderFor(*this)) {
-    for (auto ref : ep->References(ep, id().Pack())) {
-      if (auto [eptr, category] = ReferencedEntity(ep, std::get<0>(ref)); eptr) {
-        auto context = std::make_shared<ReferenceContextImpl>(ep, std::get<1>(ref));
-        co_yield Reference(std::move(eptr), std::move(context),
-                           std::get<0>(ref), category, std::get<2>(ref));
-      }
-    }
+    return References(std::move(ep), id().Pack());
   }
+  return EmptyReferences();
 }
 
 // Return the version of this token that was actually parsed. If this was a

--- a/lib/Type.cpp
+++ b/lib/Type.cpp
@@ -236,14 +236,7 @@ SpecificEntityId<TypeId> Type::id(void) const {
 
 // References to this type.
 gap::generator<Reference> Type::references(void) const & {
-  EntityProviderPtr ep = impl->ep;
-  for (auto ref : ep->References(ep, id().Pack())) {
-    if (auto [eptr, category] = ReferencedEntity(ep, std::get<0>(ref)); eptr) {
-      auto context = std::make_shared<ReferenceContextImpl>(ep, std::get<1>(ref));
-      co_yield Reference(std::move(eptr), std::move(context),
-                         std::get<0>(ref), category, std::get<2>(ref));
-    }
-  }
+  return References(impl->ep, id().Pack());
 }
 
 // TokenRange for the type


### PR DESCRIPTION
This removes ReferenceContext and ReferenceContextImpl, as those didn't make sense as there was no basis for their deduplication. Eliminate copy & paste code in generating references. Add a utility to get all references to a variadic entity.