### PR TITLE
Make it so that empty string views returned by APIs are nonetheless backed by a data pointer

### DIFF
--- a/lib/Compilation.cpp
+++ b/lib/Compilation.cpp
@@ -17,6 +17,12 @@
 #include <iostream>
 
 namespace mx {
+namespace {
+
+// A zero-sized string view that nontheless has a valid `.data()` pointer.
+static const std::string_view kEmptyStringView("");
+
+}  // namespace
 
 CompilationImpl::~CompilationImpl(void) noexcept {}
 
@@ -31,7 +37,7 @@ std::string_view CompilationImpl::SourceIR(void) const & noexcept {
       return std::string_view(mlir.cStr(), size);
     }
   }
-  return {};
+  return kEmptyStringView;
 }
 
 // Return a pointer to the source IR object.

--- a/lib/FileImpl.cpp
+++ b/lib/FileImpl.cpp
@@ -10,6 +10,12 @@
 #include <multiplier/Frontend/TokenKind.h>
 
 namespace mx {
+namespace {
+
+// A zero-sized string view that nontheless has a valid `.data()` pointer.
+static const std::string_view kEmptyStringView("");
+
+}  // namespace
 
 FileImpl::~FileImpl(void) noexcept {}
 
@@ -29,7 +35,7 @@ std::string_view FileImpl::Data(void) const & noexcept {
       return std::string_view(data.cStr(), size);
     }
   }
-  return {};
+  return kEmptyStringView;
 }
 
 // Return the number of tokens in the file.
@@ -55,7 +61,7 @@ std::string_view ReadFileTokensFromFile::NthTokenData(
     auto eo = tor[token_index + 1u];
     return std::string_view(&(file->reader.getData().cStr()[bo]), eo - bo);
   } else {
-    return {};
+    return kEmptyStringView;
   }
 }
 

--- a/lib/FragmentImpl.cpp
+++ b/lib/FragmentImpl.cpp
@@ -14,6 +14,12 @@
 #include "File.h"
 
 namespace mx {
+namespace {
+
+// A zero-sized string view that nontheless has a valid `.data()` pointer.
+static const std::string_view kEmptyStringView("");
+
+}  // namespace
 
 FragmentImpl::FragmentImpl(EntityProviderPtr ep_,
                            kj::Array<capnp::word> data_,
@@ -87,7 +93,7 @@ std::string_view ReadMacroTokensFromFragment::NthTokenData(
     EntityOffset ti) const {
   if (ti >= fragment->num_tokens) {
     assert(false);
-    return {};
+    return kEmptyStringView;
   }
 
   const auto &reader = fragment->reader;
@@ -307,13 +313,13 @@ std::string_view ReadParsedTokensFromFragment::NthTokenData(
     EntityOffset to) const {
   if (to >= fragment->num_parsed_tokens) {
     assert(false);
-    return {};
+    return kEmptyStringView;
   }
 
   auto ti = fragment->reader.getParsedTokenOffsetToIndex()[to];
   if (ti >= fragment->num_tokens) {
     assert(false);
-    return {};
+    return kEmptyStringView;
   }
 
   return this->ReadMacroTokensFromFragment::NthTokenData(ti);
@@ -456,7 +462,7 @@ std::string_view FragmentImpl::Data(void) const & noexcept {
       return std::string_view(toks.cStr(), size);
     }
   }
-  return {};
+  return kEmptyStringView;
 }
 
 // Return the token associated with a specific entity ID.

--- a/lib/Re2.cpp
+++ b/lib/Re2.cpp
@@ -8,9 +8,15 @@
 
 #include <cassert>
 
-#ifndef MX_DISABLE_RE2
-
 namespace mx {
+namespace {
+
+// A zero-sized string view that nontheless has a valid `.data()` pointer.
+static const std::string_view kEmptyStringView("");
+
+}  // namespace
+
+#ifndef MX_DISABLE_RE2
 
 // NOTE(pag): `RE2::FindAndConsume` is a variadic function taking additional
 //            arguments per sub-match, hence the requirement for enclosing
@@ -72,7 +78,7 @@ std::string_view RegexQuery::pattern(void) const {
     // NOTE(pag): Need to remove the wrapping `(` and `)`.
     return std::string_view(impl->pattern).substr(1u, impl->pattern.size() - 2u);
   } else {
-    return {};
+    return kEmptyStringView;
   }
 }
 
@@ -81,10 +87,7 @@ bool RegexQuery::is_valid(void) const {
   return impl && impl->IsValid();
 }
 
-}  // namespace mx
 #else
-
-namespace mx {
 
 // NOTE(pag): `RE2::FindAndConsume` is a variadic function taking additional
 //            arguments per sub-match, hence the requirement for enclosing
@@ -112,7 +115,7 @@ void RegexQuery::for_each_match(
 
 // Returns the underlying pattern.
 std::string_view RegexQuery::pattern(void) const {
-    return {};
+    return kEmptyStringView;
 }
 
 // Returns `true` if we successfully compiled this regular expression.
@@ -120,5 +123,5 @@ bool RegexQuery::is_valid(void) const {
   return false;
 }
 
-}  // namespace mx
 #endif   // MX_DISABLE_RE2
+}  // namespace mx

--- a/lib/Re2Impl.cpp
+++ b/lib/Re2Impl.cpp
@@ -16,9 +16,15 @@
 #include "Types.h"
 #include "Util.h"
 
-#ifndef MX_DISABLE_RE2
-
 namespace mx {
+namespace {
+
+// A zero-sized string view that nontheless has a valid `.data()` pointer.
+static const std::string_view kEmptyStringView("");
+
+}  // namespace
+
+#ifndef MX_DISABLE_RE2
 
 RegexQueryResultImpl::~RegexQueryResultImpl(void) noexcept {}
 
@@ -345,7 +351,7 @@ std::string_view RegexQueryMatch::data(void) const noexcept {
   auto real_impl = dynamic_cast<const RegexQueryMatchImpl *>(impl.get());
   if (!real_impl) {
     assert(false);
-    return {};
+    return kEmptyStringView;
   }
 
   return real_impl->matched_ranges[0];
@@ -453,9 +459,7 @@ gap::generator<RegexQueryMatch> RegexQuery::match_fragments(
   }
 }
 
-}  // namespace mx
 #else
-namespace mx {
 
 RegexQueryMatchImpl::~RegexQueryMatchImpl(void) {}
 
@@ -538,7 +542,7 @@ size_t RegexQueryMatch::num_captures(void) const {
 // The actual range of matched data. This is possibly a sub-sequence of
 // `this->TokenRange::data()`.
 std::string_view RegexQueryMatch::data(void) const noexcept {
-  return {};
+  return kEmptyStringView;
 }
 
 // Return a list of matched variables.
@@ -567,6 +571,5 @@ RegexQuery::match_fragments(const Fragment &) const & {
   co_return;
 }
 
-}  // namespace mx
 #endif   // MX_DISABLE_RE2
-
+}  // namespace mx

--- a/lib/Token.cpp
+++ b/lib/Token.cpp
@@ -29,6 +29,12 @@
 #include "Type.h"
 
 namespace mx {
+namespace {
+
+// A zero-sized string view that nontheless has a valid `.data()` pointer.
+static const std::string_view kEmptyStringView("");
+
+}  // namespace
 
 class TemplateDecl;
 
@@ -934,7 +940,7 @@ TokenKind InvalidTokenReader::NthTokenKind(EntityOffset) const {
 
 // Return the data of the Nth token.
 std::string_view InvalidTokenReader::NthTokenData(EntityOffset) const {
-  return {};
+  return kEmptyStringView;
 }
 
 // Return the id of the token from which the Nth token is derived.
@@ -1129,7 +1135,7 @@ TokenCategory CustomTokenReader::NthTokenCategory(EntityOffset to) const {
 // Return the data of the Nth token.
 std::string_view CustomTokenReader::NthTokenData(EntityOffset to) const {
   if ((to + 1u) >= data_offset.size()) {
-    return {};
+    return kEmptyStringView;
   }
 
   auto begin_offset = data_offset[to];
@@ -1138,7 +1144,7 @@ std::string_view CustomTokenReader::NthTokenData(EntityOffset to) const {
       begin_offset > data.size() ||
       end_offset > data.size()) {
     assert(false);
-    return {};
+    return kEmptyStringView;
   }
 
   return std::string_view(data).substr(
@@ -1470,7 +1476,7 @@ std::optional<unsigned> TokenRange::index_of(const Token &that) const noexcept {
 // token range.
 std::string_view TokenRange::data(void) const & {
   if (!impl || impl.get() == kInvalidTokenReader.get() || !num_tokens) {
-    return {};
+    return kEmptyStringView;
   }
 
   auto data_begin = impl->NthTokenData(index);
@@ -1478,7 +1484,7 @@ std::string_view TokenRange::data(void) const & {
 
   if (data_begin.data() > data_end.data()) {
     assert(false);
-    return {};
+    return kEmptyStringView;
   }
 
   auto size = static_cast<size_t>(data_end.data() - data_begin.data()) +
@@ -1486,7 +1492,7 @@ std::string_view TokenRange::data(void) const & {
 
   if (static_cast<EntityOffset>(size) != size) {
     assert(false);
-    return {};
+    return kEmptyStringView;
   }
 
   return std::string_view(data_begin.data(), size);

--- a/lib/Type.cpp
+++ b/lib/Type.cpp
@@ -13,6 +13,12 @@
 #include "Types.h"
 
 namespace mx {
+namespace {
+
+// A zero-sized string view that nontheless has a valid `.data()` pointer.
+static const std::string_view kEmptyStringView("");
+
+}  // namespace
 
 // Return the number of tokens in the fragment.
 EntityOffset ReadTypeTokens::NumTokens(void) const {
@@ -30,7 +36,7 @@ TokenKind ReadTypeTokens::NthTokenKind(EntityOffset to) const {
 // Return the data of the Nth token.
 std::string_view ReadTypeTokens::NthTokenData(EntityOffset to) const {
   if (to >= type->num_type_tokens) {
-    return {};
+    return kEmptyStringView;
   }
 
   const auto &reader = type->frag_reader;
@@ -145,7 +151,7 @@ std::string_view TypeImpl::Data(void) const & noexcept {
       return std::string_view(toks.cStr(), size);
     }
   }
-  return {};
+  return kEmptyStringView;
 }
 
 // Return the token associated with a specific entity ID.


### PR DESCRIPTION
This helps keep downstream code simpler, e.g. because then you can always ask for `.data()` and `.size()` for things like UTF-8 to other format conversions.